### PR TITLE
Added license name

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+The MIT License (MIT)
+
 Copyright (c) 2013 Harry Marr
 
 Permission is hereby granted, free of charge, to any person


### PR DESCRIPTION
tl;dr : Added licese name at top of file, as it makes easy to understand which license it is, rather then reading the full text.

Hope I am not being too picky, sending in a one line PR for the license file. Feel free to reject! Personally, When I want to use an opensource project and if I don't see the license name, I tend to read the full license to check if there are any changes or additions to the clauses of standard license text. If I see the license name, I don't read ahead. Mentioning the license name saves time trying to figure out what license it is and if there are any changes to it, specially for noobs.
